### PR TITLE
Prep for hl merge

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -3,10 +3,15 @@ set -e
 
 # To build with tests, install cmocka-dev and define EXTRA_CMAKE_FLAGS as:
 # EXTRA_CMAKE_FLAGS=-DUNIT_TESTING=ON
+# Also make sure that gcc-8 is used when building the test suite.  If it isn't, add (e.g.) -DCMAKE_C_COMPILER=gcc-8 -DCMAKE_CXX_COMPILER=g++-8
+# to EXTRA_CMAKE_FLAGS.  See example below:
+# EXTRA_CMAKE_FLAGS="-DUNIT_TESTING=ON -DCMAKE_VERBOSE_MAKEFILE=1 -DCMAKE_C_COMPILER=gcc-8 -DCMAKE_CXX_COMPILER=g++-8"
 
 SRCDIR=`dirname $0`
 BUILDDIR="$SRCDIR/build"
 
+# Ensure "clean-start" by removing any prior build first
+rm -rf "$BUILDDIR"
 mkdir -p "$BUILDDIR"
 
 if hash cmake3 2>/dev/null; then
@@ -18,5 +23,9 @@ fi
 
 cd "$BUILDDIR"
 
-$CMAKE -DCMAKE_BUILD_TYPE="Release" ${EXTRA_CMAKE_FLAGS:-} ..
-make -j8
+CMD="$CMAKE -DCMAKE_BUILD_TYPE="Release" ${EXTRA_CMAKE_FLAGS:-} .."
+echo $CMD
+eval $CMD
+CMD="make -j"$(nproc)
+echo $CMD
+eval $CMD

--- a/include/specs/goya/goya_packets.h
+++ b/include/specs/goya/goya_packets.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: MIT
  *
- * Copyright 2017-2018 HabanaLabs, Ltd.
+ * Copyright 2017-2019 HabanaLabs, Ltd.
  * All Rights Reserved.
  *
  */
@@ -40,15 +40,42 @@ enum goya_dma_direction {
 	DMA_ENUM_MAX
 };
 
+/* IMPORTANT NOTE: Userspace code *must* write the packets in LE format,
+ * irrespective of the host architecture.
+ * In particular, userspace code generating packets need to 
+ * include the <endian.h> header file and perform any needed
+ * conversion with the htoleXX() macros.
+ * See tests/hlthunk_tests_goya.c as an example.
+ * This is necessary since the H/W processing these packets is LE
+ * architecture. The habanalabs Kernel Mode Driver (KMD) will 
+ * perform any necessary conversion to CPU (and back to LE) for any needed packet
+ * introspection, validation, and patching, before sending off 
+ * to the H/W.
+ *
+ * Also note that we still need separate bit-field mappings 
+ * depending on the architecture.  This isn't due to 
+ * endianness per se. It's due to the way the compiler packs the bits. On
+ * LE, bits are packed from right to left.  On BE, bits are packed
+ * from left to right.  Thus, in order to maintain the same bit order,
+ * the mappings need to be mirror images of each other.
+ */
 struct packet_nop {
 	__u32 reserved;
 	union {
 		struct {
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
 			__u32:24;
 			__u32 opcode :5;
 			__u32 eng_barrier :1;
 			__u32 reg_barrier :1;
 			__u32 msg_barrier :1;
+#else //mirror image for BE systems
+			__u32 msg_barrier :1;
+			__u32 reg_barrier :1;
+			__u32 eng_barrier :1;
+			__u32 opcode :5;
+			__u32:24;
+#endif
 		};
 		__u32 ctl;
 	};
@@ -58,11 +85,19 @@ struct packet_stop {
 	__u32 reserved;
 	union {
 		struct {
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
 			__u32:24;
 			__u32 opcode :5;
 			__u32 eng_barrier :1;
 			__u32 reg_barrier :1; /* must be 0 */
 			__u32 msg_barrier :1; /* must be 0 */
+#else //mirror image for BE systems
+			__u32 msg_barrier :1; /* must be 0 */
+			__u32 reg_barrier :1; /* must be 0 */
+			__u32 eng_barrier :1;
+			__u32 opcode :5;
+			__u32:24;
+#endif
 		};
 		__u32 ctl;
 	};
@@ -72,6 +107,7 @@ struct packet_wreg32 {
 	__u32 value;
 	union {
 		struct {
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
 			__u32 reg_offset :16;
 			__u32:7;
 			__u32 local :1; /* 0: write to TCL regs,
@@ -81,20 +117,55 @@ struct packet_wreg32 {
 			__u32 eng_barrier :1;
 			__u32 reg_barrier :1; /* must be 1 */
 			__u32 msg_barrier :1;
+#else //mirror image for BE systems
+			__u32 msg_barrier :1;
+			__u32 reg_barrier :1; /* must be 1 */
+			__u32 eng_barrier :1;
+			__u32 opcode :5;
+			__u32 local :1; /* 0: write to TCL regs,
+					 * 1: write to CMDQ regs
+					 */
+			__u32:7;
+			__u32 reg_offset :16;
+#endif
 		};
 		__u32 ctl;
 	};
 };
 
 struct packet_wreg_bulk {
-	__u32 size64 :16;
-	__u32:16;
-	__u32 reg_offset :16;
-	__u32:8;
-	__u32 opcode :5;
-	__u32 eng_barrier :1;
-	__u32 reg_barrier :1; /* must be 1 */
-	__u32 msg_barrier :1;
+	union {
+		struct {
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+			__u32 size64 :16;
+			__u32:16;
+#else //mirror image for BE systems
+			__u32:16;
+			__u32 size64 :16;
+#endif
+		};
+		__u32 __size64;
+	};
+	union {
+		struct {
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+			__u32 reg_offset :16;
+			__u32:8;
+			__u32 opcode :5;
+			__u32 eng_barrier :1;
+			__u32 reg_barrier :1; /* must be 1 */
+			__u32 msg_barrier :1;
+#else //mirror image for BE systems
+			__u32 msg_barrier :1;
+			__u32 reg_barrier :1; /* must be 1 */
+			__u32 eng_barrier :1;
+			__u32 opcode :5;
+			__u32:8;
+			__u32 reg_offset :16;
+#endif
+		};
+		__u32 ctl;
+	};
 	__u64 values[0]; /* data starts here */
 };
 
@@ -102,6 +173,7 @@ struct packet_msg_long {
 	__u32 value;
 	union {
 		struct {
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
 			__u32:16;
 			__u32 weakly_ordered :1;
 			__u32 no_snoop :1;
@@ -112,6 +184,18 @@ struct packet_msg_long {
 			__u32 eng_barrier :1;
 			__u32 reg_barrier :1;
 			__u32 msg_barrier :1;
+#else //mirror image for BE systems
+			__u32 msg_barrier :1;
+			__u32 reg_barrier :1;
+			__u32 eng_barrier :1;
+			__u32 opcode :5;
+			__u32:2;
+			__u32 op :2; /* 0: write <value>. 1: write timestamp. */
+			__u32:2;
+			__u32 no_snoop :1;
+			__u32 weakly_ordered :1;
+			__u32:16;
+#endif
 		};
 		__u32 ctl;
 	};
@@ -121,20 +205,34 @@ struct packet_msg_long {
 struct packet_msg_short {
 	union {
 		struct {
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
 			__u32 sync_id :10;
 			__u32:5;
 			__u32 mode : 1;
 			__u32 sync_value :16;
+#else //mirror image for BE systems
+			__u32 sync_value :16;
+			__u32 mode : 1;
+			__u32:5;
+			__u32 sync_id :10;
+#endif
 		} mon_arm_register;
 		struct {
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
 			__u32 sync_value :16;
 			__u32:15;
 			__u32 mode :1;
+#else //mirror image for BE systems
+			__u32 mode :1;
+			__u32:15;
+			__u32 sync_value :16;
+#endif
 		} so_upd;
 		__u32 value;
 	};
 	union {
 		struct {
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
 			__u32 msg_addr_offset :16;
 			__u32 weakly_ordered :1;
 			__u32 no_snoop :1;
@@ -145,6 +243,18 @@ struct packet_msg_short {
 			__u32 eng_barrier :1;
 			__u32 reg_barrier :1;
 			__u32 msg_barrier :1;
+#else //mirror image for BE systems
+			__u32 msg_barrier :1;
+			__u32 reg_barrier :1;
+			__u32 eng_barrier :1;
+			__u32 opcode :5;
+			__u32 base :2;
+			__u32 op :2;
+			__u32:2;
+			__u32 no_snoop :1;
+			__u32 weakly_ordered :1;
+			__u32 msg_addr_offset :16;
+#endif
 		};
 		__u32 ctl;
 	};
@@ -154,6 +264,7 @@ struct packet_msg_prot {
 	__u32 value;
 	union {
 		struct {
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
 			__u32:16;
 			__u32 weakly_ordered :1;
 			__u32 no_snoop :1;
@@ -164,6 +275,18 @@ struct packet_msg_prot {
 			__u32 eng_barrier :1;
 			__u32 reg_barrier :1;
 			__u32 msg_barrier :1;
+#else //mirror image for BE systems
+			__u32 msg_barrier :1;
+			__u32 reg_barrier :1;
+			__u32 eng_barrier :1;
+			__u32 opcode :5;
+			__u32:2;
+			__u32 op :2; /* 0: write <value>. 1: write timestamp. */
+			__u32:2;
+			__u32 no_snoop :1;
+			__u32 weakly_ordered :1;
+			__u32:16;
+#endif
 		};
 		__u32 ctl;
 	};
@@ -171,22 +294,49 @@ struct packet_msg_prot {
 };
 
 struct packet_fence {
-	__u32 dec_val :4;
-	__u32:12;
-	__u32 gate_val :8;
-	__u32:6;
-	__u32 id :2;
-	__u32:24;
-	__u32 opcode :5;
-	__u32 eng_barrier :1;
-	__u32 reg_barrier :1;
-	__u32 msg_barrier :1;
+	union {
+		struct {
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+			__u32 dec_val :4;
+			__u32:12;
+			__u32 gate_val :8;
+			__u32:6;
+			__u32 id :2;
+#else //mirror image for BE systems
+			__u32 id :2;
+			__u32:6;
+			__u32 gate_val :8;
+			__u32:12;
+			__u32 dec_val :4;
+#endif
+		};
+		__u32 cfg;
+	};
+	union {
+		struct {
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+			__u32:24;
+			__u32 opcode :5;
+			__u32 eng_barrier :1;
+			__u32 reg_barrier :1;
+			__u32 msg_barrier :1;
+#else //mirror image for BE systems
+			__u32 msg_barrier :1;
+			__u32 reg_barrier :1;
+			__u32 eng_barrier :1;
+			__u32 opcode :5;
+			__u32:24;
+#endif
+		};
+		__u32 ctl;
+	};
 };
 
 struct packet_lin_dma {
 	__u32 tsize;
 	union {
 		struct {
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
 			__u32 weakly_ordered :1; /* H/W bug, must be 1 */
 			__u32 rdcomp :1;
 			__u32 wrcomp :1;
@@ -202,6 +352,23 @@ struct packet_lin_dma {
 			__u32 eng_barrier :1;
 			__u32 reg_barrier :1; /* must be 1 */
 			__u32 msg_barrier :1;
+#else //mirror image for BE systems
+			__u32 msg_barrier :1;
+			__u32 reg_barrier :1; /* must be 1 */
+			__u32 eng_barrier :1;
+			__u32 opcode :5;
+			__u32:1;
+			__u32 dma_dir :3; /* S/W only, no effect on HW */
+			__u32 cntrl :12;
+			__u32 tensor_dma :1; /* N/A, must be 0 */
+			__u32 memset_mode :1;
+			__u32 dst_disable :1;
+			__u32 src_disable :1;
+			__u32 no_snoop :1;
+			__u32 wrcomp :1;
+			__u32 rdcomp :1;
+			__u32 weakly_ordered :1; /* H/W bug, must be 1 */
+#endif
 		};
 		__u32 ctl;
 	};
@@ -213,6 +380,7 @@ struct packet_cp_dma {
 	__u32 tsize;
 	union {
 		struct {
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
 			__u32 weakly_ordered :1;
 			__u32 no_snoop :1;
 			__u32:22;
@@ -220,6 +388,15 @@ struct packet_cp_dma {
 			__u32 eng_barrier :1;
 			__u32 reg_barrier :1; /* must be 1 */
 			__u32 msg_barrier :1;
+#else //mirror image for BE systems
+			__u32 msg_barrier :1;
+			__u32 reg_barrier :1; /* must be 1 */
+			__u32 eng_barrier :1;
+			__u32 opcode :5;
+			__u32:22;
+			__u32 no_snoop :1;
+			__u32 weakly_ordered :1;
+#endif
 		};
 		__u32 ctl;
 	};

--- a/tests/hlthunk_tests_goya.c
+++ b/tests/hlthunk_tests_goya.c
@@ -11,6 +11,7 @@
 #include "goya/goya_packets.h"
 #include "goya/asic_reg/goya_regs.h"
 
+#include <endian.h>
 #include <errno.h>
 #include <stdio.h>
 #include <string.h>
@@ -25,6 +26,8 @@ static uint32_t goya_add_nop_pkt(void *buffer, uint32_t buf_off, bool eb,
 	packet.eng_barrier = eb;
 	packet.msg_barrier = mb;
 	packet.reg_barrier = 1;
+
+	packet.ctl = htole32(packet.ctl);
 
 	return hltests_add_packet_to_cb(buffer, buf_off, &packet,
 						sizeof(packet));
@@ -43,6 +46,10 @@ static uint32_t goya_add_msg_long_pkt(void *buffer, uint32_t buf_off,
 	packet.msg_barrier = pkt_info->mb;
 	packet.reg_barrier = 1;
 
+	packet.ctl = htole32(packet.ctl);
+	packet.value = htole32(packet.value);
+	packet.addr = htole64(packet.addr);
+
 	return hltests_add_packet_to_cb(buffer, buf_off, &packet,
 						sizeof(packet));
 }
@@ -60,6 +67,9 @@ static uint32_t goya_add_msg_short_pkt(void *buffer, uint32_t buf_off,
 	packet.eng_barrier = pkt_info->eb;
 	packet.msg_barrier = pkt_info->mb;
 	packet.reg_barrier = 1;
+
+	packet.ctl = htole32(packet.ctl);
+	packet.value = htole32(packet.value);
 
 	return hltests_add_packet_to_cb(buffer, buf_off, &packet,
 						sizeof(packet));
@@ -81,6 +91,9 @@ static uint32_t goya_add_arm_monitor_pkt(void *buffer, uint32_t buf_off,
 	packet.eng_barrier = pkt_info->eb;
 	packet.msg_barrier = pkt_info->mb;
 	packet.reg_barrier = 1;
+
+	packet.ctl = htole32(packet.ctl);
+	packet.value = htole32(packet.value);
 
 	return hltests_add_packet_to_cb(buffer, buf_off, &packet,
 							sizeof(packet));
@@ -104,6 +117,9 @@ static uint32_t goya_add_write_to_sob_pkt(void *buffer, uint32_t buf_off,
 	packet.so_upd.sync_value = pkt_info->write_to_sob.value;
 	packet.so_upd.mode = pkt_info->write_to_sob.mode;
 
+	packet.ctl = htole32(packet.ctl);
+	packet.value = htole32(packet.value);
+
 	return hltests_add_packet_to_cb(buffer, buf_off, &packet,
 							sizeof(packet));
 }
@@ -121,6 +137,9 @@ static uint32_t goya_add_fence_pkt(void *buffer, uint32_t buf_off,
 	packet.eng_barrier = pkt_info->eb;
 	packet.msg_barrier = pkt_info->mb;
 	packet.reg_barrier = 1;
+
+	packet.ctl = htole32(packet.ctl);
+	packet.cfg = htole32(packet.cfg);
 
 	return hltests_add_packet_to_cb(buffer, buf_off, &packet,
 						sizeof(packet));
@@ -142,6 +161,11 @@ static uint32_t goya_add_dma_pkt(void *buffer, uint32_t buf_off,
 	packet.tsize = pkt_info->dma.size;
 	packet.dma_dir = pkt_info->dma.dma_dir;
 
+	packet.ctl = htole32(packet.ctl);
+	packet.tsize = htole32(packet.tsize);
+	packet.src_addr = htole64(packet.src_addr);
+	packet.dst_addr = htole64(packet.dst_addr);
+
 	return hltests_add_packet_to_cb(buffer, buf_off, &packet,
 						sizeof(packet));
 }
@@ -158,6 +182,10 @@ static uint32_t goya_add_cp_dma_pkt(void *buffer, uint32_t buf_off,
 	packet.reg_barrier = 1;
 	packet.src_addr = pkt_info->cp_dma.src_addr;
 	packet.tsize = pkt_info->cp_dma.size;
+
+	packet.ctl = htole32(packet.ctl);
+	packet.tsize = htole32(packet.tsize);
+	packet.src_addr = htole64(packet.src_addr);
 
 	return hltests_add_packet_to_cb(buffer, buf_off, &packet,
 						sizeof(packet));


### PR DESCRIPTION
Hi Oded, 

Please review the changes I made in hl-thunk / userspace for BE support.  Note I provided separate mappings for BE and LE in goya_packets.h so the bit-fields line up.  I also perform the needed htoleXX() conversions in hlthunk_tests_goya.c to ensure all packets are written in LE format.

I updated two structs packet_wreg_bulk, and packet_fence to more closely match the definitions in the KMD.